### PR TITLE
Time-related bug in saveNetCDF

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,11 +20,11 @@ Suggests:
     ncdf4 (>= 1.9),
     testthat (>= 1.0.2),
     knitr
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: c( person("Ben", "Bond-Lamberty", role = c("aut")),
     person("Kathe", "Todd-Brown", role = c("aut", "cre"), email =
     "ktoddbrown@gmail.com") )
 License: MIT + file LICENSE
 VignetteBuilder: knitr
 LazyData: true
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -24,9 +24,3 @@ import(abind)
 import(assertthat)
 import(digest)
 import(dplyr)
-
-  importFrom("grDevices", "rainbow")
-  importFrom("stats", "quantile", "runif")
-  importFrom("utils", "capture.output", "object.size", "packageVersion",
-             "setTxtProgressBar", "txtProgressBar", "write.csv")
-  

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,9 @@
 
+RCMIP5 1.2.1
+===========
+* Fix `saveNetCDF` bug (#149)
+
+
 RCMIP5 1.2
 ===========
 

--- a/R/saveNetCDF.R
+++ b/R/saveNetCDF.R
@@ -76,8 +76,8 @@ saveNetCDF <- function(x, file=NULL, path="./", verbose=FALSE, saveProvenance=TR
         if(verbose) cat("Defining time dimension...")
         assert_that(!is.null(x$debug$timeUnit))
         assert_that(!is.null(x$debug$timeRaw))
-        assert_that(!is.null(x$calendarStr))
-        timedim <- ncdf4::ncdim_def(dimNames[length(dimNames)], x$debug$timeUnit, x$debug$timeRaw, calendar=x$calendarStr)
+        assert_that(!is.null(x$debug$calendarStr))
+        timedim <- ncdf4::ncdim_def(dimNames[length(dimNames)], x$debug$timeUnit, x$debug$timeRaw, calendar=x$debug$calendarStr)
         dimlist[[length(dimlist)+1]] <- timedim     
     }
     

--- a/man/RCMIP5.Rd
+++ b/man/RCMIP5.Rd
@@ -27,4 +27,3 @@ Taylor et al., 2012:
   Meteorological Society, 93, 485-498.
   \url{http://dx.doi.org/10.1175/BAMS-D-11-00094.1}
 }
-

--- a/man/checkTimePeriod.Rd
+++ b/man/checkTimePeriod.Rd
@@ -45,4 +45,3 @@ checkTimePeriod(getFileInfo())
 \seealso{
 \code{\link{getFileInfo}}
 }
-

--- a/man/getFileInfo.Rd
+++ b/man/getFileInfo.Rd
@@ -37,4 +37,3 @@ getFileInfo('.', recursive=FALSE)
 \seealso{
 \code{\link{checkTimePeriod}}
 }
-

--- a/man/loadEnsemble.Rd
+++ b/man/loadEnsemble.Rd
@@ -49,4 +49,3 @@ the \code{val} component as a multidimensional array, not a data frame.
 This is an internal RCMIP5 function and not exported.
 }
 \keyword{internal}
-


### PR DESCRIPTION
`calendarStr` was moved into a `debug` object, and `saveNetCDF` wasn’t
updated. We’d really like a test that mimics what @aridus does in #149
- read and write a file.

Fixes #149